### PR TITLE
Fix typo in API Reference README

### DIFF
--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -131,9 +131,9 @@ You can pass information to the config object to configure meta information out 
   } />
 ```
 
-#### metaData?: object
+#### hiddenClients?: array
 
-You can pass a list of [httpsnippet clients](https://github.com/Kong/httpsnippet/wiki/Targets) to hide from the clients menu.
+You can pass an array of [httpsnippet clients](https://github.com/Kong/httpsnippet/wiki/Targets) to hide from the clients menu.
 
 ```vue
 <ApiReference :configuration="{


### PR DESCRIPTION
Fix `hiddenClients` README section header

**Problem**
Currently, the API Reference README section header for `hiddenClients` reads `metaData?: object`

**Explanation**
This happens because of a typo

**Solution**
With this PR the API Reference README section header for `hiddenClients` reads `hiddenClients?: array`
